### PR TITLE
Alist fixes for alarm.dm and atmos_control.dm

### DIFF
--- a/code/WorkInProgress/Mini/atmos_control.dm
+++ b/code/WorkInProgress/Mini/atmos_control.dm
@@ -300,7 +300,7 @@ Nitrous Oxide
 			output += {"
 <a href='?src=\ref[src];alarm=\ref[current];screen=[AALARM_SCREEN_MAIN]'>Main menu</a><br>
 <b>Air machinery mode for the area:</b><ul>"}
-			var/list/modes = list(AALARM_MODE_SCRUBBING   = "d_filtering - Scrubs out contaminants",\
+			var/alist/modes = alist(AALARM_MODE_SCRUBBING   = "d_filtering - Scrubs out contaminants",\
 					AALARM_MODE_REPLACEMENT = "<font color='blue'>Replace Air - Siphons out air while replacing</font>",\
 					AALARM_MODE_PANIC       = "<font color='red'>Panic - Siphons air out of the room</font>",\
 					AALARM_MODE_CYCLE       = "<font color='red'>Cycle - Siphons air before replacing</font>",\

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -999,7 +999,7 @@ Nitrous Oxide
 
 		if (AALARM_SCREEN_MODE)
 			output += "<a href='?src=\ref[src];screen=[AALARM_SCREEN_MAIN]'>Main menu</a><br><b>Air machinery mode for the area:</b><ul>"
-			var/list/modes = list(AALARM_MODE_SCRUBBING   = "d_filtering - Scrubs out contaminants",\
+			var/alist/modes = alist(AALARM_MODE_SCRUBBING   = "d_filtering - Scrubs out contaminants",\
 				AALARM_MODE_REPLACEMENT = "<font color='blue'>Replace Air - Siphons out air while replacing</font>",\
 				AALARM_MODE_PANIC       = "<font color='red'>Panic - Siphons air out of the room</font>",\
 				AALARM_MODE_CYCLE       = "<font color='red'>Cycle - Siphons air before replacing</font>",\


### PR DESCRIPTION
Lummox, that fat bastard made it so that all associative lists that use numbers as indices have to be alists now. Subsequently old code, such as NSV Luna cannot be compiled without this fix. 

For what it's worth, I don't know who this'll be useful to anymore. SS13's dying and I have my doubts on whether or not someone else will make anything new from Luna in the coming years. 

I know there's a few projects that already exist, but they've had a long time to cook. 
One thing I'll say though is that at a glance I'm pretty sure Luna beats about every modern codebase. I wasn't expecting it to be as small and simple as it is.